### PR TITLE
Fix operation order for Lamport timestamps

### DIFF
--- a/_posts/2017-02-12-what-are-lamport-timestamps.md
+++ b/_posts/2017-02-12-what-are-lamport-timestamps.md
@@ -25,7 +25,7 @@ void send_message(char* msg, int to) {
 }
 
 void on_receive_message(msg_t msg) {
-  timestamp = max(timestamp, msg.timestamp + 1);
+  timestamp = max(timestamp, msg.timestamp) + 1;
 }
 ```
 


### PR DESCRIPTION
The max is taken first, and then the increment applied. This is consistent with the rest of the post, such as “To join processes, create a new process with timestamp max(all timestamps)+1”.