### PR TITLE
Break apart two commands within code block

### DIFF
--- a/_posts/2019-01-08-how-to-run-redis-sentinel.md
+++ b/_posts/2019-01-08-how-to-run-redis-sentinel.md
@@ -260,7 +260,10 @@ but we never started one!
 Let's start one:
 
 ```console
-$ redis-server --port 6380 &
+$ redis-server --port 6380
+```
+&
+```console
 $ redis-cli -p 6380 slaveof 127.0.0.1 6379
 ```
 

--- a/_posts/2019-01-08-how-to-run-redis-sentinel.md
+++ b/_posts/2019-01-08-how-to-run-redis-sentinel.md
@@ -257,12 +257,15 @@ but this gets aborted:
 
 To fail over, Sentinel needs a slave to fail over to,
 but we never started one!
-Let's start one:
+Let's start a new Redis:
 
 ```console
 $ redis-server --port 6380
+...
 ```
-&
+
+Then from a new shell, set it as the slave:
+
 ```console
 $ redis-cli -p 6380 slaveof 127.0.0.1 6379
 ```


### PR DESCRIPTION
The code block gave the impression that these two commands would be run from a single command line execution.  However, the first command will not return, and even if we were using '&&', the second command won't run.
By breaking the code-block, placing the '&' on a different line, and then starting a new code-block, we add clarity.

BTW. This was the best redis-sentinel "get started" page I found.  Thank you!