### PR TITLE
Fixed example of 2,3 in homogeneous form

### DIFF
--- a/_posts/2020-11-28-homogeneous-coordinates-in-2d-from-scratch.md
+++ b/_posts/2020-11-28-homogeneous-coordinates-in-2d-from-scratch.md
@@ -35,7 +35,7 @@ Or again, the point `[2,3]`
 is modelled by all points that pass through the straight line going through `[0,0,0]` and `[2,3,1]` (the laser line).
 Or again more formally,
 the two-dimensional point `[2,3]`
-is modelled by all three-dimensional points `[2/w, 3/w, w]`.
+is modelled by all three-dimensional points `[2w, 3w, w]`.
 
 We can _translate_ the two-dimensional drawing on the `w=1` plane
 by skewing space.


### PR DESCRIPTION
Cartesian coordinates are mapped to homogeneous coordinates by multiplying by w, not dividing.  Mapping from homogeneous back to Cartesian uses division.