### PR TITLE
fix: handle scroll overflow for code blocks

### DIFF
--- a/assets/all.css
+++ b/assets/all.css
@@ -46,7 +46,7 @@ Future fix: wrap code blocks in another wrapper, but this requires some JS/plugi
 */
 code { background: #eee; }
 #content pre { max-width: none; width: 100%; margin-right: 0; overflow-x: auto; }
-#content pre > code { display: block; max-width: 50em; margin: 0 auto; }
+#content pre > code { display: block; max-width: 50em; margin: 0 auto; overflow: auto; padding: 1rem; border-radius: 0.5rem; }
 
 td, th { text-align: left; padding-right: 1em; vertical-align: top; }
 a:link, a:visited { text-decoration: none; }


### PR DESCRIPTION
css fixes for code block include
- add overflow
- add padding
- add border-radius

code block after the change
![code block after the change](https://github.com/jameshfisher/jameshfisher.com/assets/9116255/1e827362-5180-4a8e-89a8-b8f213e3d025)
